### PR TITLE
UIに細かな調整を加えた

### DIFF
--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -257,16 +257,20 @@ fun Viewer(
             Text("Destination: ${destination.latitude}, ${destination.longitude}")
             Text("Distance: $distance")
             Text("headTo: $headTo")
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(40.dp))
         }
         Button(
             modifier = Modifier
-                .align(Alignment.CenterHorizontally),
+                .align(Alignment.CenterHorizontally)
+                .width(300.dp),
             onClick = {
                 changeBottomSheetState(true)
             }
         ){
-            Text("目的地を変更")
+            Text(
+                text = "目的地を変更",
+                fontSize = 20.sp
+            )
         }
 
         Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -200,7 +200,7 @@ fun PermissionRequestView(
 
 @Composable
 fun Viewer(
-    viewModel: MainActivityViewModel
+    viewModel: MainActivityViewModel,
 ) {
     val ctx = LocalContext.current
     val debugFeatureFlag = ctx.debugFeatureFlag.data.map { preference ->
@@ -326,12 +326,14 @@ fun Viewer(
                     Button(
                         onClick = {
                             onClickDestinationChoice(destination)
-                        scope.launch { sheetState.hide() }.invokeOnCompletion {
-                            if (!sheetState.isVisible) {
-                                changeBottomSheetState(false)
+                            scope.launch {
+                                sheetState.hide()
+                            }.invokeOnCompletion {
+                                if (!sheetState.isVisible) {
+                                    changeBottomSheetState(false)
+                                }
                             }
-                        }
-                    },
+                        },
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(

--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material3.Button
@@ -258,9 +259,13 @@ fun Viewer(
             Text("headTo: $headTo")
             Spacer(Modifier.height(8.dp))
         }
-        Button(onClick = {
-            changeBottomSheetState(true)
-        }){
+        Button(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally),
+            onClick = {
+                changeBottomSheetState(true)
+            }
+        ){
             Text("目的地を変更")
         }
 

--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -334,7 +334,9 @@ fun Viewer(
                                 }
                             }
                         },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
                     ) {
                         Text(
                             destination.name,

--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -47,7 +47,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -62,6 +65,7 @@ import com.example.stray_compass.resource.locationIntentLongitude
 import kotlinx.coroutines.launch
 import com.example.stray_compass.resource.mainActivityDebugTextPreference
 import kotlinx.coroutines.flow.map
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 class MainActivity : ComponentActivity() {
@@ -240,6 +244,8 @@ fun Viewer(
     @OptIn(ExperimentalMaterial3Api::class)
     val sheetState = rememberModalBottomSheetState()
 
+    val minSquareWidth = min(LocalConfiguration.current.screenWidthDp, LocalConfiguration.current.screenHeightDp)
+
     Column(
         modifier = Modifier.padding(16.dp)
     ) {
@@ -265,6 +271,18 @@ fun Viewer(
             modifier = Modifier
                 .fillMaxSize()
         ) {
+            Spacer(
+                modifier = Modifier
+                    .size(height = minSquareWidth.dp, width = minSquareWidth.dp)
+                    .drawBehind {
+                        drawCircle(Color(0xFF0F0F0F))
+                        drawCircle(
+                            color = Color(0xFFFAFAFA),
+                            radius = size.minDimension / 2.05f,
+                        )
+                    }
+            )
+
             Text(
                 text = "REMAINING\n${distance.roundToInt() / 1000.0} [km]",
                 textAlign = TextAlign.Center,
@@ -276,6 +294,7 @@ fun Viewer(
             Icon(
                 imageVector = Icons.Filled.Navigation,
                 contentDescription = "Navigation",
+                tint = Color(0xFFE00A0A),
                 modifier = Modifier
                     .size(64.dp)
                     .graphicsLayer {


### PR DESCRIPTION
close #5 

- NavigationIconの周りに枠を表示するようにした
- NavigationIconの色をFigmaに適合する色に変えた
- ボトムシート内のボタン幅を調整
- 「目的地を変更」ボタンの位置、サイズを調整