### PR TITLE
向かうべき方向を算出する処理が全く異なる値を計算結果として出していた問題を修正

### DIFF
--- a/app/src/main/java/com/example/stray_compass/LocationExtension.kt
+++ b/app/src/main/java/com/example/stray_compass/LocationExtension.kt
@@ -2,7 +2,11 @@ package com.example.stray_compass
 
 import android.location.Location
 
-fun doubleToLocation(lat: Double, lng: Double): Location {
+/**
+ * Create a Location object from two Double values.
+ * lng = Longitude (緯度), lat = Latitude (経度).
+ */
+fun doubleToLocation(lng: Double, lat: Double): Location {
     val location = Location(null)
     location.latitude = lat
     location.longitude = lng

--- a/app/src/main/java/com/example/stray_compass/LocationService.kt
+++ b/app/src/main/java/com/example/stray_compass/LocationService.kt
@@ -29,9 +29,9 @@ class LocationService: Service() {
     private val locationListener = LocationListener { p0 ->
         val currentLatitude = p0.latitude
         val currentLongitude = p0.longitude
-        Log.d("Location", "${currentLatitude}, $currentLongitude")
+        Log.d("Location", "$currentLongitude, $currentLatitude")
 
-        broadcastLocation(currentLatitude, currentLongitude)
+        broadcastLocation(currentLongitude, currentLatitude)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/example/stray_compass/MainActivity.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivity.kt
@@ -252,9 +252,10 @@ fun Viewer(
     ) {
         if (debugFeatureFlag) {
             Text("azimuth: $azimuth")
-            Text("latitude: $latitude")
-            Text("longitude: $longitude")
-            Text("Destination: ${destination.latitude}, ${destination.longitude}")
+            Text("Current Longitude: $longitude")
+            Text("Current Latitude: $latitude")
+            Text("Dest Longitude: ${destination.longitude}")
+            Text("Dest Latitude: ${destination.latitude}")
             Text("Distance: $distance")
             Text("headTo: $headTo")
             Spacer(Modifier.height(40.dp))

--- a/app/src/main/java/com/example/stray_compass/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/stray_compass/MainActivityViewModel.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.example.stray_compass.resource.Destination
+import com.example.stray_compass.resource.destinationList
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.floor
@@ -20,7 +21,7 @@ import kotlin.math.sin
 class MainActivityViewModel(
     private val sensorManager: SensorManager,
     initialTrippingState: TripState = TripState.Tripping(
-        doubleToLocation(41.759167, 140.704444) // 函館山
+        destinationList[0].location // 函館山
     )
 ): ViewModel(), SensorEventListener {
     var currentLocation = doubleToLocation(0.0, 0.0)

--- a/app/src/main/java/com/example/stray_compass/resource/destinationData.kt
+++ b/app/src/main/java/com/example/stray_compass/resource/destinationData.kt
@@ -9,10 +9,11 @@ data class Destination(
 )
 
 val destinationList = listOf(
-    Destination("函館山", doubleToLocation(41.759167, 140.704444)),
-    Destination("立待岬", doubleToLocation(41.74564393712656, 140.72217385783742)),
-    Destination("新函館北斗駅", doubleToLocation(41.904975472356206, 140.64916583040576)),
-    Destination("新中野ダム", doubleToLocation(41.87060500660374, 140.78680017848293)),
-    Destination("北海道東照宮", doubleToLocation(41.839274713428516, 140.78669408732782)),
-    Destination("蔦屋書店", doubleToLocation(41.83622834602887, 140.7494532874035))
+    Destination("函館山", doubleToLocation(41.7603614, 140.7045022)),
+    Destination("立待岬", doubleToLocation(41.7452515, 140.7215674)),
+    Destination("函館熱帯植物園", doubleToLocation(41.7740046, 140.7895020)),
+    Destination("新函館北斗駅", doubleToLocation(41.9046990, 140.6483768)),
+    Destination("新中野ダム", doubleToLocation(41.8706050, 140.7868001)),
+    Destination("北海道東照宮", doubleToLocation(41.8386536, 140.7850566)),
+    Destination("蔦屋書店", doubleToLocation(41.8306748, 140.7356658))
 )


### PR DESCRIPTION
close #10 

# 何が起こっていたのか

- `doubleToLocation`という関数があって、それには`Double`を二つ渡せば`Location`というクラスを返してくれるようになっていた。
- `doubleToLocation`は第一引数にLatitude、第二引数にLongitudeをとる、いわば(x, y)的な表現方法を扱っていた。
- 一方で、他の部分では(y, x)的な表現方法を採用しており、思わぬところで緯度と経度が全て逆になっていた。

## なぜ函館山展望台では問題にならなかったのか？

- 未来大、および美原1丁目から 5π/4 の位置に函館山展望台があるため。
  - つまり、計算結果は当然間違っていたが、正しい値と誤りの値がほぼ同じになる場所をたまたまテストケースとして選んでいたため。

# 再発防止策を考える

- `doubleToLocation`に確実に誤った値が入った場合の例外処理を追加する
  - 北緯、南緯は90°までなので、 [-90, 90]の範囲内にない値がlongitudeに渡された場合、例外を発出するようにする
- そもそも`doubleToLocation`の引数を明示していなかったことにも問題がある。
  - これは実装担当者が気をつけたり、コードレビューの段階で弾くなどの努力が必要になる。
  - とは言っても、実装担当者が逆に覚えていることもあるので、今回はKotlinのDocument CommentにLatitudeとLongitude、どちらが緯度でどちらが経度かを書いておいた。